### PR TITLE
Qt 6.2 compatibility

### DIFF
--- a/qt6/CMakeLists.txt
+++ b/qt6/CMakeLists.txt
@@ -1,6 +1,5 @@
 find_package(Qt6 CONFIG REQUIRED Core Widgets)
 
-qt_standard_project_setup()
 
 set(plastikstyle6_SRC
   plastikstyle.cpp

--- a/qt6/plastikstyle.cpp
+++ b/qt6/plastikstyle.cpp
@@ -87,7 +87,7 @@ static const int blueFrameWidth =  2;  // with of line edit focus frame
 
 #include "qstylehelper.h"
 #include "qstylecache.h"
-#include <QMutableVectorIterator>
+#include "qvector.h"
 
 // from windows style
 static const int windowsItemFrame        =  2; // menu item frame width


### PR DESCRIPTION
In the README PlastikStyle is declared compatible with Qt 6.2. However, on my local system it does not build against 6.2.

This PR solves the build issues.

- Remove qt_standard_project_setup [(only available starting with Qt 6.3)](https://doc.qt.io/qt-6/qt-standard-project-setup.html)
- Substitute `#include <QMutableVectorIterator>` which apparently is not found.